### PR TITLE
update macros to use exported paths, not crate-private paths

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! seesaw_device {
             pub const fn default_addr() -> u8 {
                 $default_addr
             }
-            pub const fn hardware_id() -> $crate::common::HardwareId {
+            pub const fn hardware_id() -> $crate::HardwareId {
                 $hardware_id
             }
             pub const fn product_id() -> u16 {
@@ -32,11 +32,11 @@ macro_rules! seesaw_device {
             }
         }
 
-        impl<D: $crate::driver::Driver> $crate::SeesawDevice for $name<D> {
+        impl<D: $crate::Driver> $crate::SeesawDevice for $name<D> {
             type Driver = D;
             type Error = $crate::SeesawError<D::I2cError>;
             const DEFAULT_ADDR: u8 = $default_addr;
-            const HARDWARE_ID: $crate::common::HardwareId = $hardware_id;
+            const HARDWARE_ID: $crate::HardwareId = $hardware_id;
             const PRODUCT_ID: u16 = $product_id;
 
             fn addr(&self) -> u8 {
@@ -66,28 +66,26 @@ macro_rules! seesaw_device {
 #[macro_export(local_inner_macros)]
 macro_rules! impl_device_module {
     ($device:ident, AdcModule $({})?) => {
-        impl<D: $crate::driver::Driver> $crate::modules::adc::AdcModule<D> for $device<D> {}
+        impl<D: $crate::Driver> $crate::modules::adc::AdcModule<D> for $device<D> {}
     };
     ($device:ident, EncoderModule { button_pin: $button_pin:expr }) => {
-        impl<D: $crate::driver::Driver> $crate::modules::encoder::EncoderModule<D> for $device<D> {
+        impl<D: $crate::Driver> $crate::modules::encoder::EncoderModule<D> for $device<D> {
             const ENCODER_BTN_PIN: u8 = $button_pin;
         }
     };
     ($device:ident, GpioModule $({})?) => {
-        impl<D: $crate::driver::Driver> $crate::modules::gpio::GpioModule<D> for $device<D> {}
+        impl<D: $crate::Driver> $crate::modules::gpio::GpioModule<D> for $device<D> {}
     };
     ($device:ident, NeopixelModule { num_leds: $num_leds:expr, pin: $pin:expr }) => {
-        impl<D: $crate::driver::Driver> $crate::modules::neopixel::NeopixelModule<D>
-            for $device<D>
-        {
+        impl<D: $crate::Driver> $crate::modules::neopixel::NeopixelModule<D> for $device<D> {
             const N_LEDS: u16 = $num_leds;
             const PIN: u8 = $pin;
         }
     };
     ($device:ident, StatusModule $({})?) => {
-        impl<D: $crate::driver::Driver> $crate::modules::StatusModule<D> for $device<D> {}
+        impl<D: $crate::Driver> $crate::modules::StatusModule<D> for $device<D> {}
     };
     ($device:ident, TimerModule $({})?) => {
-        impl<D: $crate::driver::Driver> $crate::modules::timer::TimerModule<D> for $device<D> {}
+        impl<D: $crate::Driver> $crate::modules::timer::TimerModule<D> for $device<D> {}
     };
 }


### PR DESCRIPTION
When I try to use the [Creating Your Own Devices](https://github.com/alexeden/adafruit-seesaw#creating-your-own-devices) example from the readme, I get an error about modules not being visible.

### Failure setup
```shell
$ cargo new --lib example
$ cd example/
$ cargo add adafruit-seesaw
$ echo 'adafruit_seesaw::seesaw_device! {
    name: MyDevice,
    hardware_id: adafruit_seesaw::HardwareId::ATTINY817,
    product_id: 1234,
    default_addr: 0x99,
    modules: [
        GpioModule,
        NeopixelModule { num_leds: 6, pin: 1 },
    ]
}' > src/lib.rs
$ cargo check
```

<details>
<summary>Error messages</summary>

```
error[E0603]: module `common` is private
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/macros.rs:27:51
   |
27 |             pub const fn hardware_id() -> $crate::common::HardwareId {
   |                                                   ^^^^^^ private module
   |
note: the module `common` is defined here
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/lib.rs:7:1
   |
7  | mod common;
   | ^^^^^^^^^^
help: consider importing this enum instead
   |
27 |             pub const fn hardware_id() -> adafruit_seesaw::HardwareId {
   |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0603]: module `driver` is private
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/macros.rs:35:25
   |
35 |         impl<D: $crate::driver::Driver> $crate::SeesawDevice for $name<D> {
   |                         ^^^^^^ private module
   |
note: the module `driver` is defined here
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/lib.rs:9:1
   |
9  | mod driver;
   | ^^^^^^^^^^
help: consider importing this trait instead
   |
35 |         impl<D: adafruit_seesaw::Driver> $crate::SeesawDevice for $name<D> {
   |                 ~~~~~~~~~~~~~~~~~~~~~~~

error[E0603]: module `common` is private
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/macros.rs:39:40
   |
39 |             const HARDWARE_ID: $crate::common::HardwareId = $hardware_id;
   |                                        ^^^^^^ private module
   |
note: the module `common` is defined here
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/lib.rs:7:1
   |
7  | mod common;
   | ^^^^^^^^^^
help: consider importing this enum instead
   |
39 |             const HARDWARE_ID: adafruit_seesaw::HardwareId = $hardware_id;
   |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0603]: module `driver` is private
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/macros.rs:77:25
   |
77 |         impl<D: $crate::driver::Driver> $crate::modules::gpio::GpioModule<D> for $device<D> {}
   |                         ^^^^^^ private module
   |
note: the module `driver` is defined here
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/lib.rs:9:1
   |
9  | mod driver;
   | ^^^^^^^^^^
help: consider importing this trait instead
   |
77 |         impl<D: adafruit_seesaw::Driver> $crate::modules::gpio::GpioModule<D> for $device<D> {}
   |                 ~~~~~~~~~~~~~~~~~~~~~~~

error[E0603]: module `driver` is private
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/macros.rs:80:25
   |
80 |         impl<D: $crate::driver::Driver> $crate::modules::neopixel::NeopixelModule<D>
   |                         ^^^^^^ private module
   |
note: the module `driver` is defined here
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/adafruit-seesaw-0.5.2/src/lib.rs:9:1
   |
9  | mod driver;
   | ^^^^^^^^^^
help: consider importing this trait instead
   |
80 |         impl<D: adafruit_seesaw::Driver> $crate::modules::neopixel::NeopixelModule<D>
   |                 ~~~~~~~~~~~~~~~~~~~~~~~

For more information about this error, try `rustc --explain E0603`.
error: could not compile `example` (lib) due to 5 previous errors
```

</details>


### Proposed solution
It seems like the macro emits `$crate::common::HardwareId` and `$crate::driver::Driver`, but the `common` and `driver` modules are private.

This PR updates the macro:
- From `$crate::common::HardwareId` to `$crate::HardwareId`
- From `$crate::driver::Driver` to `$crate::Driver`
