### PR TITLE
Remove extra 0 written to neopixel buffer

### DIFF
--- a/src/modules/neopixel.rs
+++ b/src/modules/neopixel.rs
@@ -76,7 +76,7 @@ pub trait NeopixelModule<D: Driver>: SeesawDevice<Driver = D> {
         let addr = self.addr();
 
         self.driver()
-            .register_write(addr, SET_BUF, &[zero, one, r, g, b, 0x00])
+            .register_write(addr, SET_BUF, &[zero, one, r, g, b])
             .map_err(SeesawError::I2c)
     }
 
@@ -97,7 +97,7 @@ pub trait NeopixelModule<D: Driver>: SeesawDevice<Driver = D> {
                 self.driver().register_write(
                     addr,
                     SET_BUF,
-                    &[zero, one, color.0, color.1, color.2, 0x00],
+                    &[zero, one, color.0, color.1, color.2],
                 )
             })
             .map_err(SeesawError::I2c)


### PR DESCRIPTION
The extra 0 impacts the next RGB NeoPixel's value. So updating pixel 0 only while pixel 1 is lit red will make pixel 1 turn off.

```
    neotrellis.set_nth_neopixel_color(1, 0x0f, 0x0, 0);
    neotrellis.set_nth_neopixel_color(0, 0x0, 0x0f, 0xf); // turns off pixel 0.
```

I didn't see anything obvious from the history of the file why that 0 is there, but removing it results in correct behavior.