### PR TITLE
Update to embedded-hal 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ bench = false
 test = false
 
 [dependencies]
-embedded-hal = "0.2"
-shared-bus = "0.2"
+embedded-hal = "1.0.0"
+shared-bus = "0.3.1"
 
 [dev-dependencies]
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
-rtt-target = { version = "0.3", features = ["cortex-m"] }
-stm32f4xx-hal = { features = ["rt", "stm32f405", "sdio"], version = "0.13" }
+rtt-target = { version = "0.5.0" }
+stm32f4xx-hal = { features = [ "stm32f405", "sdio"], version = "0.20.0" }
 
 [profile.release]
 codegen-units = 1

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,5 +1,5 @@
 use crate::driver::I2cDriver;
-use embedded_hal::blocking::{delay, i2c};
+use embedded_hal::{delay, i2c};
 use shared_bus::BusMutex;
 
 #[derive(Debug)]
@@ -13,7 +13,7 @@ pub struct Bus<DELAY, I2C>(pub(crate) DELAY, pub(crate) I2C);
 // Clone implementation
 impl<'a, DELAY, I2C, M> Clone for BusProxy<'a, M>
 where
-    DELAY: delay::DelayUs<u32>,
+    DELAY: delay::DelayNs,
     I2C: I2cDriver,
     M: BusMutex<Bus = Bus<DELAY, I2C>>,
 {
@@ -23,64 +23,58 @@ where
 }
 
 // Delay implementation
-impl<'a, DELAY, I2C, M> delay::DelayUs<u32> for BusProxy<'a, M>
+impl<'a, DELAY, I2C, M> delay::DelayNs for BusProxy<'a, M>
 where
-    DELAY: delay::DelayUs<u32>,
+    DELAY: delay::DelayNs,
     I2C: I2cDriver,
     M: BusMutex<Bus = Bus<DELAY, I2C>>,
 {
-    fn delay_us(&mut self, us: u32) {
-        self.mutex.lock(|bus| bus.0.delay_us(us))
+    fn delay_ns(&mut self, ns: u32) {
+        self.mutex.lock(|bus| bus.0.delay_ns(ns))
     }
 }
 
 // I2C implementations
-impl<'a, DELAY, I2C, M> i2c::Write for BusProxy<'a, M>
+impl<'a, DELAY, I2C, M> i2c::I2c for BusProxy<'a, M>
 where
-    DELAY: delay::DelayUs<u32>,
+    DELAY: delay::DelayNs,
     I2C: I2cDriver,
     M: BusMutex<Bus = Bus<DELAY, I2C>>,
 {
-    type Error = I2C::I2cError;
+    fn transaction(
+            &mut self,
+            address: u8,
+            operations: &mut [i2c::Operation<'_>],
+        ) -> Result<(), Self::Error> {
+        self.mutex
+            .lock(|bus| bus.1.transaction(address, operations))
+            .map_err(|err| err.into())
+    }
+
+    fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+        self.mutex
+            .lock(|bus| bus.1.read(address, read))
+            .map_err(|err| err.into())
+    }
 
     fn write(&mut self, addr: u8, buffer: &[u8]) -> Result<(), Self::Error> {
         self.mutex
             .lock(|bus| bus.1.write(addr, buffer))
             .map_err(|err| err.into())
     }
-}
 
-impl<'a, DELAY, I2C, M> i2c::Read for BusProxy<'a, M>
-where
-    DELAY: delay::DelayUs<u32>,
-    I2C: I2cDriver,
-    M: BusMutex<Bus = Bus<DELAY, I2C>>,
-{
-    type Error = I2C::I2cError;
-
-    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+    fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
         self.mutex
-            .lock(|bus| bus.1.read(addr, buffer))
+            .lock(|bus| bus.1.write_read(address, write, read))
             .map_err(|err| err.into())
     }
 }
 
-impl<'a, DELAY, I2C, M> i2c::WriteRead for BusProxy<'a, M>
+impl<'a, DELAY, I2C, M> i2c::ErrorType for BusProxy<'a, M>
 where
-    DELAY: delay::DelayUs<u32>,
+    DELAY: delay::DelayNs,
     I2C: I2cDriver,
     M: BusMutex<Bus = Bus<DELAY, I2C>>,
 {
-    type Error = I2C::I2cError;
-
-    fn write_read(
-        &mut self,
-        addr: u8,
-        buffer_in: &[u8],
-        buffer_out: &mut [u8],
-    ) -> Result<(), Self::Error> {
-        self.mutex
-            .lock(|bus| bus.1.write_read(addr, buffer_in, buffer_out))
-            .map_err(|err| err.into())
-    }
+    type Error = I2C::Error;
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,26 +1,24 @@
 use crate::common::Reg;
-use embedded_hal::blocking::{delay, i2c};
+use embedded_hal::{delay, i2c};
 
 const DELAY_TIME: u32 = 125;
 
 /// Blanket trait for something that implements I2C bus operations, with a
 /// combined Error associated type
 #[doc(hidden)]
-pub trait I2cDriver: i2c::Write + i2c::WriteRead + i2c::Read {
-    type I2cError: From<<Self as i2c::Write>::Error>
-        + From<<Self as i2c::WriteRead>::Error>
-        + From<<Self as i2c::Read>::Error>;
+pub trait I2cDriver: i2c::I2c {
+    type I2cError: From<<Self as i2c::ErrorType>::Error>;
 }
 
 impl<T, E> I2cDriver for T
 where
-    T: i2c::Write<Error = E> + i2c::WriteRead<Error = E> + i2c::Read<Error = E>,
+    T: i2c::I2c<Error = E>,
 {
     type I2cError = E;
 }
 
-pub trait Driver: I2cDriver + delay::DelayUs<u32> {}
-impl<T> Driver for T where T: I2cDriver + delay::DelayUs<u32> {}
+pub trait Driver: I2cDriver + delay::DelayNs {}
+impl<T> Driver for T where T: I2cDriver + delay::DelayNs {}
 
 macro_rules! impl_integer_write {
     ($fn:ident $nty:tt) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(const_evaluatable_unchecked, incomplete_features)]
 #![feature(array_try_map, generic_const_exprs)]
 // TODO improve the organization of the exports/visibility
-use embedded_hal::blocking::delay;
+use embedded_hal::delay;
 pub mod bus;
 mod common;
 pub mod devices;
@@ -30,7 +30,7 @@ pub struct Seesaw<M> {
 
 impl<DELAY, I2C, M> Seesaw<M>
 where
-    DELAY: delay::DelayUs<u32>,
+    DELAY: delay::DelayNs,
     I2C: I2cDriver,
     M: shared_bus::BusMutex<Bus = bus::Bus<DELAY, I2C>>,
 {


### PR DESCRIPTION
Tested locally, not with the stm32 though.

`shared-bus` still loops in 0.2.x of `embedded-hal`. I suspect it is not the right solution anymore given [embedded-hal-bus](https://docs.rs/embedded-hal-bus), but that might be best as a separate change.