### PR TITLE
Add Support for NeoRotary 4

### DIFF
--- a/src/devices/macros.rs
+++ b/src/devices/macros.rs
@@ -87,4 +87,7 @@ macro_rules! impl_device_module {
     ($device:ident, TimerModule $({})?) => {
         impl<D: $crate::Driver> $crate::modules::timer::TimerModule<D> for $device<D> {}
     };
+    ($device:ident, QuadEncoderModule $({})?) => {
+        impl<D: $crate::Driver> $crate::modules::quad_encoder::QuadEncoderModule<D> for $device<D> {}
+    };
 }

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -2,11 +2,13 @@ mod arcade_button_1x4;
 mod generic_device;
 pub mod macros;
 mod neokey_1x4;
+mod neorotary4;
 mod neoslider;
 mod rotary_encoder;
 pub use arcade_button_1x4::*;
 pub use generic_device::*;
 pub use neokey_1x4::*;
+pub use neorotary4::*;
 pub use neoslider::*;
 pub use rotary_encoder::*;
 

--- a/src/devices/neorotary4.rs
+++ b/src/devices/neorotary4.rs
@@ -1,14 +1,11 @@
-use super::{RotaryEncoder, SeesawDeviceInit};
+use super::SeesawDeviceInit;
 use crate::{
     modules::{
-	gpio::{GpioModule, PinMode},
 	status::StatusModule,
-	neopixel::NeopixelModule,
 	quad_encoder::QuadEncoderModule,
-	timer::TimerModule,
 	HardwareId,
     },
-    seesaw_device, Driver, SeesawError,
+    seesaw_device, Driver,
 };
 
 seesaw_device! {

--- a/src/devices/neorotary4.rs
+++ b/src/devices/neorotary4.rs
@@ -3,6 +3,7 @@ use crate::{
     modules::{
 	status::StatusModule,
 	quad_encoder::QuadEncoderModule,
+	neopixel::NeopixelModule,
 	HardwareId,
     },
     seesaw_device, Driver,
@@ -23,6 +24,7 @@ seesaw_device! {
 impl<D: Driver> SeesawDeviceInit<D> for NeoRotary4<D> {
     fn init(mut self) -> Result<Self, Self::Error> {
 	self.reset_and_verify_seesaw()
+	    .and_then(|_| self.enable_neopixel())
 	    .and_then(|_| self.enable_button(0))
 	    .and_then(|_| self.enable_button(1))
 	    .and_then(|_| self.enable_button(2))

--- a/src/devices/neorotary4.rs
+++ b/src/devices/neorotary4.rs
@@ -1,0 +1,35 @@
+use super::{RotaryEncoder, SeesawDeviceInit};
+use crate::{
+    modules::{
+	gpio::{GpioModule, PinMode},
+	status::StatusModule,
+	neopixel::NeopixelModule,
+	quad_encoder::QuadEncoderModule,
+	timer::TimerModule,
+	HardwareId,
+    },
+    seesaw_device, Driver, SeesawError,
+};
+
+seesaw_device! {
+    name: NeoRotary4,
+    hardware_id: HardwareId::ATTINY817,
+    product_id: 5752,
+    default_addr: 0x49,
+    modules: [
+	QuadEncoderModule,
+	GpioModule,
+	NeopixelModule { num_leds: 4, pin: 18 }
+    ]
+}
+
+impl<D: Driver> SeesawDeviceInit<D> for NeoRotary4<D> {
+    fn init(mut self) -> Result<Self, Self::Error> {
+	self.reset_and_verify_seesaw()
+	    .and_then(|_| self.enable_button(0))
+	    .and_then(|_| self.enable_button(1))
+	    .and_then(|_| self.enable_button(2))
+	    .and_then(|_| self.enable_button(3))
+	    .map(|_| self)
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -4,6 +4,7 @@ pub mod gpio;
 pub mod neopixel;
 pub mod status;
 pub mod timer;
+pub mod quad_encoder;
 
 pub type Reg = [u8; 2];
 

--- a/src/modules/quad_encoder.rs
+++ b/src/modules/quad_encoder.rs
@@ -1,0 +1,61 @@
+use super::{
+    gpio::{GpioModule, PinMode},
+    Modules, Reg,
+};
+use crate::{Driver, DriverExt, SeesawError};
+
+#[allow(dead_code)]
+const STATUS: &Reg = &[Modules::Encoder.into_u8(), 0x00];
+const INT_SET: &Reg = &[Modules::Encoder.into_u8(), 0x10];
+const INT_CLR: &Reg = &[Modules::Encoder.into_u8(), 0x20];
+const POSITION: &Reg = &[Modules::Encoder.into_u8(), 0x30];
+const DELTA: &Reg = &[Modules::Encoder.into_u8(), 0x40];
+
+pub trait QuadEncoderModule<D: Driver>: GpioModule<D> {
+    const ENCODER_ID: [u8;4] = [0x0, 0x1, 0x2, 0x3];
+    const ENCODER_BTN_PIN: [u8;4] = [12, 14, 17, 9];
+
+    fn enable_button(&mut self, button: usize) -> Result<(), SeesawError<D::Error>> {
+        self.set_pin_mode(Self::ENCODER_BTN_PIN[button], PinMode::InputPullup)
+            .map(|_| self.driver().delay_us(125))
+    }
+
+    fn button(&mut self, button: usize) -> Result<bool, SeesawError<D::Error>> {
+        self.digital_read(Self::ENCODER_BTN_PIN[button])
+    }
+
+    fn delta(&mut self, encoder: usize) -> Result<i32, SeesawError<D::Error>> {
+        let addr = self.addr();
+        self.driver()
+            .read_i32(addr, &[DELTA[0],DELTA[1] | Self::ENCODER_ID[encoder]])
+            .map_err(SeesawError::I2c)
+    }
+
+    fn disable_interrupt(&mut self, encoder: usize) -> Result<(), SeesawError<D::Error>> {
+        let addr = self.addr();
+        self.driver()
+            .write_u8(addr, &[INT_CLR[0], INT_CLR[1] | Self::ENCODER_ID[encoder]], 1)
+            .map_err(SeesawError::I2c)
+    }
+
+    fn enable_interrupt(&mut self, encoder: usize) -> Result<(), SeesawError<D::Error>> {
+        let addr = self.addr();
+        self.driver()
+            .write_u8(addr, &[INT_SET[0], INT_SET[1] | Self::ENCODER_ID[encoder]], 1)
+            .map_err(SeesawError::I2c)
+    }
+
+    fn position(&mut self, encoder: usize) -> Result<i32, SeesawError<D::Error>> {
+        let addr = self.addr();
+        self.driver()
+            .read_i32(addr, &[POSITION[0], POSITION[1] | Self::ENCODER_ID[encoder]])
+            .map_err(SeesawError::I2c)
+    }
+
+    fn set_position(&mut self, encoder: usize, pos: i32) -> Result<(), SeesawError<D::Error>> {
+        let addr = self.addr();
+        self.driver()
+            .write_i32(addr, &[POSITION[0], POSITION[1] | Self::ENCODER_ID[encoder]], pos)
+            .map_err(SeesawError::I2c)
+    }
+}


### PR DESCRIPTION
This adds support for the Adafruit NeoRotary 4 (Product ID: 5752)

I tested it by modifying the encoder example on a raspi zero 2 W with std and embeddel-hal.
I didn't add the test to not add a dependency on the rppal crate.