### PR TITLE
Add and re-export rgb crate for color handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,26 @@ and this project (hopefully) adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
-### To Be Added
+### Added
 
-- [Add definition for the NeoDriver meopixel driver board](https://www.adafruit.com/product/5766)
+- [#14](https://github.com/alexeden/adafruit-seesaw/pull/14) Add and re-export the [`rgb`](https://docs.rs/rgb/0.8.50/rgb/index.html) crate for all things related to color
+
+### Modified
+
+- **BREAKING** [#14](https://github.com/alexeden/adafruit-seesaw/pull/14) The `NeopixelModule` now has a `Color` associated type that must implement the `ComponentSlice<u8>` trait from the `rgb` crate
+  - For convenience, any device that implements the `NeopixelModule` trait exports a type alias for its `Color` type, e.g. `NeoKey1x4Color`
+  - The `impl_device_module!` macro has been updated accordingly when implementing the `NeopixelModule` for a device:
+    - Before: `NeopixelModule { num_leds: 4, pin: 3 }`
+    - After: `NeopixelModule<color_type = NeoKey1x4Color> { num_leds: 4, pin: 3 }`
+- **BREAKING** [#14](https://github.com/alexeden/adafruit-seesaw/pull/14) Functions that set handle colors in the `NeopixelModule` now take their `Color` associated type as parameters
+  - Before: `fn set_neopixel_color(&mut self, r: u8, g: u8, b: u8)`
+  - After: `fn set_neopixel_color(&mut self, color: Self::Color)`
+  - Before: `fn set_nth_neopixel_color(&mut self, n: usize, r: u8, g: u8, b: u8)`
+  - After: `fn set_nth_neopixel_color(&mut self, n: usize, color: Self::Color)`
+  - Before: `fn set_neopixel_colors(&mut self, colors: &[(u8, u8, u8); Self::N_LEDS as usize])`
+  - After: `fn set_neopixel_colors(&mut self, colors: &[Self::Color; Self::N_LEDS])`
+- [#14](https://github.com/alexeden/adafruit-seesaw/pull/14) All device examples have been updated to use the new `NeopixelModule` API
+- [#12](https://github.com/alexeden/adafruit-seesaw/pull/12) The `register_write` function on the `Driver` trait has been modified such that it no longer uses/needs const generics for buffer sizing (thanks @dsheets)
 
 ## [0.9.0] - 2025-01-31
 
@@ -18,7 +35,6 @@ and this project (hopefully) adheres to [Semantic Versioning](https://semver.org
 - [#8](https://github.com/alexeden/adafruit-seesaw/pull/8) Digital write functions within the Seesaw GPIO module
 - [#13](https://github.com/alexeden/adafruit-seesaw/pull/13) Adds example demo for the [Adafruit's quad rotary encoder device](https://www.adafruit.com/product/5752)
 
-
 ### Modified
 
 - **BREAKING** [#13](https://github.com/alexeden/adafruit-seesaw/pull/13) Updates the `EncoderModule` to support both single and multiple encoder devices (see PR for details)
@@ -26,7 +42,6 @@ and this project (hopefully) adheres to [Semantic Versioning](https://semver.org
 ### Removed
 
 - **BREAKING** [#13](https://github.com/alexeden/adafruit-seesaw/pull/13) Removes the `QuadEncoderModule` (see PR for details)
-
 
 ## [0.8.0] - 2025-01-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ test = false
 
 [dependencies]
 embedded-hal = "1.0.0"
+rgb = "0.8"
 
 [dev-dependencies]
 cortex-m = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ test = false
 
 [dependencies]
 embedded-hal = "1.0.0"
-rgb = "0.8"
+rgb = "0.8.50"
 
 [dev-dependencies]
 cortex-m = "0.7"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The library follows the patterns of the [`shared-bus`](https://github.com/Rahix/
 
 Communicating with Seesaw devices requires a bus that implements both `I2C` traits and `Delay` from `embedded-hal`.
 
-# Using in a `#![no_std]` context
+# Default Usage (`#![no_std]`)
 
 If you're communicating with devices within a single thread, use the `SeesawRefCell` typed struct, which uses the `RefCellBus` wrapper to enable sharing of the bus across multiple Seesaw devices.
 
@@ -28,7 +28,7 @@ let mut neokeys = NeoKey1x4::new_with_default_addr(seesaw.acquire_driver())
     .expect("Failed to start NeoKey1x4");
 ```
 
-# Using across multiple threads
+# Using across multiple threads (`std`)
 
 > This requires turning on the `std` feature flag.
 
@@ -88,7 +88,7 @@ fn main() -> Result<(), anyhow::Error> {
 }
 ```
 
-# Creating a Device
+# Using a Device
 
 All devices implement the `SeesawDevice` trait and have the same constructor function, along with lots of other device-specific information.
 
@@ -112,7 +112,7 @@ let neokeys = NeoKey1x4::new_with_default_addr(seesaw.acquire_driver());
 let neokeys = NeoKey1x4::new(0x00, seesaw.acquire_driver());
 ```
 
-# Initializing Devices
+### Initializing
 
 Devices that implement `SeesawDevice` also implmement `SeesawDeviceInit`, which defines a device-specific `init` function for setting up a device's hardware functionality. The intention is to run a set of sensible defaults so you don't have to remember to do it yourself.
 
@@ -168,7 +168,7 @@ Now you can use the new device as you would any other:
 ```rs
 let neokeys = NeoKey2x3::new_with_default_addr(seesaw.acquire_driver())
     .init()
-    .expect("Failed to initialize NeoKey1x4");
+    .expect("Failed to initialize NeoKey2x3");
 ```
 
 # Implementation Progress

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ seesaw_device! {
     default_addr: _,
     modules: [
         GpioModule,
-        NeopixelModule { num_leds: 6, pin: _ },
+        NeopixelModule<color_type = rgb::Rgb<u8>> { num_leds: 6, pin: _ },
     ]
 }
 ```

--- a/examples/neokey_1x4_test.rs
+++ b/examples/neokey_1x4_test.rs
@@ -2,13 +2,17 @@
 #![no_main]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
-use adafruit_seesaw::{devices::NeoKey1x4, prelude::*, SeesawRefCell};
+use adafruit_seesaw::{
+    devices::{NeoKey1x4, NeoKey1x4Color},
+    prelude::*,
+    SeesawRefCell,
+};
 use cortex_m_rt::entry;
 use rtt_target::{rprintln, rtt_init_print};
 use stm32f4xx_hal::{gpio::GpioExt, i2c::I2c, pac, prelude::*, rcc::RccExt};
 
-const RED: (u8, u8, u8) = (255, 0, 0);
-const GREEN: (u8, u8, u8) = (0, 255, 0);
+const RED: NeoKey1x4Color = NeoKey1x4Color { r: 255, g: 0, b: 0 };
+const GREEN: NeoKey1x4Color = NeoKey1x4Color { r: 0, g: 255, b: 0 };
 
 #[entry]
 fn main() -> ! {

--- a/examples/neotrellis_ripples.rs
+++ b/examples/neotrellis_ripples.rs
@@ -119,7 +119,7 @@ fn main() -> ! {
 
         // Update neopixels
         trellis
-            .set_neopixel_colors_new(&matrix)
+            .set_neopixel_colors(&matrix)
             .and_then(|_| trellis.sync_neopixel())
             .expect("Failed to update neopixels");
     }

--- a/examples/neotrellis_ripples.rs
+++ b/examples/neotrellis_ripples.rs
@@ -39,10 +39,6 @@ const COLORS: [Color; 6] = [
     },
 ];
 
-// type Color =
-//     <adafruit_seesaw::devices::NeoTrellis<Driver> as
-// adafruit_seesaw::prelude::NeopixelModule<_>>::Color;
-
 #[entry]
 fn main() -> ! {
     rtt_init_print!();
@@ -62,6 +58,8 @@ fn main() -> ! {
         .expect("Failed to start NeoTrellis");
 
     rprintln!("Trellis started");
+
+    // Listen for key presses
     for x in 0..trellis.num_cols() {
         for y in 0..trellis.num_rows() {
             trellis

--- a/examples/rotary_encoder_test.rs
+++ b/examples/rotary_encoder_test.rs
@@ -2,7 +2,11 @@
 #![no_main]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
-use adafruit_seesaw::{devices::RotaryEncoder, prelude::*, SeesawRefCell};
+use adafruit_seesaw::{
+    devices::{RotaryEncoder, RotaryEncoderColor},
+    prelude::*,
+    SeesawRefCell,
+};
 use cortex_m_rt::entry;
 use rtt_target::{rprintln, rtt_init_print};
 use stm32f4xx_hal::{gpio::GpioExt, i2c::I2c, pac, prelude::*, rcc::RccExt};
@@ -34,15 +38,14 @@ fn main() -> ! {
     let mut prev_position = 0;
     loop {
         let position = encoder.position(0).expect("Failed to get position");
+        let c = color_wheel(((position & 0xFF) as u8).wrapping_mul(3));
         if position != prev_position {
             prev_position = position;
-            rprintln!("Position changed to {}", position);
+            rprintln!("Position changed to {}, new color is {:?}", position, c);
         }
-        let c = color_wheel(((position & 0xFF) as u8).wrapping_mul(3));
-        let Color(r, g, b) = c.set_brightness(255);
 
         encoder
-            .set_neopixel_color(r, g, b)
+            .set_neopixel_color(c)
             .and_then(|_| encoder.sync_neopixel())
             .expect("Failed to set neopixel");
 
@@ -68,22 +71,22 @@ fn handle_panic(info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-fn color_wheel(byte: u8) -> Color {
+fn color_wheel(byte: u8) -> RotaryEncoderColor {
     match byte {
-        0..=84 => Color(255 - byte * 3, 0, byte * 3),
-        85..=169 => Color(0, (byte - 85) * 3, 255 - (byte - 85) * 3),
-        _ => Color((byte - 170) * 3, 255 - (byte - 170) * 3, 0),
-    }
-}
-
-struct Color(pub u8, pub u8, pub u8);
-
-impl Color {
-    pub fn set_brightness(self, brightness: u8) -> Self {
-        Self(
-            ((self.0 as u16 * brightness as u16) >> 8) as u8,
-            ((self.1 as u16 * brightness as u16) >> 8) as u8,
-            ((self.2 as u16 * brightness as u16) >> 8) as u8,
-        )
+        0..=84 => RotaryEncoderColor {
+            r: 255 - byte * 3,
+            g: 0,
+            b: byte * 3,
+        },
+        85..=169 => RotaryEncoderColor {
+            r: 0,
+            g: (byte - 85) * 3,
+            b: 255 - (byte - 85) * 3,
+        },
+        _ => RotaryEncoderColor {
+            r: (byte - 170) * 3,
+            g: 255 - (byte - 170) * 3,
+            b: 0,
+        },
     }
 }

--- a/src/devices/macros.rs
+++ b/src/devices/macros.rs
@@ -93,9 +93,9 @@ macro_rules! impl_device_module {
     };
     ($device:ident, NeopixelModule<color_type = $color_type:ty> { num_leds: $num_leds:expr, pin: $pin:expr }) => {
         impl<D: $crate::Driver> $crate::modules::neopixel::NeopixelModule<D> for $device<D> {
-            type C = $color_type;
+            type Color = $color_type;
 
-            const N_LEDS: u16 = $num_leds;
+            const N_LEDS: usize = $num_leds;
             const PIN: u8 = $pin;
         }
     };

--- a/src/devices/macros.rs
+++ b/src/devices/macros.rs
@@ -7,8 +7,8 @@ macro_rules! seesaw_device {
         product_id: $product_id:expr,
         default_addr: $default_addr:expr,
         modules: [
-            $($module_name:ident $({
-                $($const_name:ident: $const_value:expr $(,)?),*
+            $($module_name:ident$(<$($module_param_name:ident =$module_param:ty),*>)? $({
+                $($const_name:ident: $const_value:expr),*
             })?),*
             $(,)?
         ]
@@ -57,7 +57,11 @@ macro_rules! seesaw_device {
         }
 
         $(
-            impl_device_module! { $name, $module_name $({$($const_name: $const_value),*})* }
+            impl_device_module! {
+                $name, $module_name$(<$($module_param_name = $module_param),*>)? $({
+                    $($const_name: $const_value),*
+                })*
+            }
         )*
     };
 }
@@ -87,8 +91,10 @@ macro_rules! impl_device_module {
             const NUM_ROWS: u8 = $num_rows;
         }
     };
-    ($device:ident, NeopixelModule { num_leds: $num_leds:expr, pin: $pin:expr }) => {
+    ($device:ident, NeopixelModule<color_type = $color_type:ty> { num_leds: $num_leds:expr, pin: $pin:expr }) => {
         impl<D: $crate::Driver> $crate::modules::neopixel::NeopixelModule<D> for $device<D> {
+            type C = $color_type;
+
             const N_LEDS: u16 = $num_leds;
             const PIN: u8 = $pin;
         }

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -6,6 +6,10 @@ mod neorotary4;
 mod neoslider;
 mod neotrellis;
 mod rotary_encoder;
+use crate::{
+    modules::{status::StatusModule, HardwareId},
+    Driver,
+};
 pub use arcade_button_1x4::*;
 pub use generic_device::*;
 pub use neokey_1x4::*;
@@ -13,11 +17,6 @@ pub use neorotary4::*;
 pub use neoslider::*;
 pub use neotrellis::*;
 pub use rotary_encoder::*;
-
-use crate::{
-    modules::{status::StatusModule, HardwareId},
-    Driver,
-};
 
 pub trait SeesawDevice {
     type Error;

--- a/src/devices/neokey_1x4.rs
+++ b/src/devices/neokey_1x4.rs
@@ -17,9 +17,11 @@ seesaw_device! {
   default_addr: 0x30,
   modules: [
       GpioModule,
-      NeopixelModule<color_type = rgb::Rgb<u8>> { num_leds: 4, pin: 3 },
+      NeopixelModule<color_type = NeoKey1x4Color> { num_leds: 4, pin: 3 },
   ]
 }
+
+pub type NeoKey1x4Color = rgb::Grb<u8>;
 
 impl<D: Driver> SeesawDeviceInit<D> for NeoKey1x4<D> {
     fn init(mut self) -> Result<Self, Self::Error> {

--- a/src/devices/neokey_1x4.rs
+++ b/src/devices/neokey_1x4.rs
@@ -17,7 +17,7 @@ seesaw_device! {
   default_addr: 0x30,
   modules: [
       GpioModule,
-      NeopixelModule { num_leds: 4, pin: 3 },
+      NeopixelModule<color_type = rgb::Rgb<u8>> { num_leds: 4, pin: 3 },
   ]
 }
 

--- a/src/devices/neorotary4.rs
+++ b/src/devices/neorotary4.rs
@@ -16,9 +16,11 @@ seesaw_device! {
     modules: [
         EncoderModule { num_encoders: 4, encoder_btn_pins: [12, 14, 17, 9] },
         GpioModule,
-        NeopixelModule<color_type = rgb::Rgb<u8>> { num_leds: 4, pin: 18 }
+        NeopixelModule<color_type = NeoRotary4Color> { num_leds: 4, pin: 18 }
     ]
 }
+
+pub type NeoRotary4Color = rgb::Grb<u8>;
 
 impl<D: Driver> SeesawDeviceInit<D> for NeoRotary4<D> {
     fn init(mut self) -> Result<Self, Self::Error> {

--- a/src/devices/neorotary4.rs
+++ b/src/devices/neorotary4.rs
@@ -16,7 +16,7 @@ seesaw_device! {
     modules: [
         EncoderModule { num_encoders: 4, encoder_btn_pins: [12, 14, 17, 9] },
         GpioModule,
-        NeopixelModule { num_leds: 4, pin: 18 }
+        NeopixelModule<color_type = rgb::Rgb<u8>> { num_leds: 4, pin: 18 }
     ]
 }
 

--- a/src/devices/neoslider.rs
+++ b/src/devices/neoslider.rs
@@ -13,7 +13,7 @@ seesaw_device!(
   modules: [
       AdcModule,
       GpioModule,
-      NeopixelModule { num_leds: 4, pin: 14},
+      NeopixelModule<color_type = rgb::Rgb<u8>> {  num_leds: 4, pin: 14 },
   ]
 );
 

--- a/src/devices/neoslider.rs
+++ b/src/devices/neoslider.rs
@@ -13,9 +13,11 @@ seesaw_device!(
   modules: [
       AdcModule,
       GpioModule,
-      NeopixelModule<color_type = rgb::Rgb<u8>> {  num_leds: 4, pin: 14 },
+      NeopixelModule<color_type = NeoSliderColor> {  num_leds: 4, pin: 14 },
   ]
 );
+
+pub type NeoSliderColor = rgb::Grb<u8>;
 
 impl<D: Driver> SeesawDeviceInit<D> for NeoSlider<D> {
     fn init(mut self) -> Result<Self, Self::Error> {

--- a/src/devices/neotrellis.rs
+++ b/src/devices/neotrellis.rs
@@ -10,7 +10,7 @@ seesaw_device! {
     product_id: 3954,
     default_addr: 0x2E,
     modules: [
-        NeopixelModule { num_leds: 16, pin: 3 },
+        NeopixelModule<color_type = rgb::Rgb<u8>> { num_leds: 16, pin: 3 },
         KeypadModule { num_cols: 4, num_rows: 4 },
     ]
 }

--- a/src/devices/neotrellis.rs
+++ b/src/devices/neotrellis.rs
@@ -10,10 +10,12 @@ seesaw_device! {
     product_id: 3954,
     default_addr: 0x2E,
     modules: [
-        NeopixelModule<color_type = rgb::Rgb<u8>> { num_leds: 16, pin: 3 },
+        NeopixelModule<color_type = NeoTrellisColor> { num_leds: 16, pin: 3 },
         KeypadModule { num_cols: 4, num_rows: 4 },
     ]
 }
+
+pub type NeoTrellisColor = rgb::Grb<u8>;
 
 impl<D: Driver> SeesawDeviceInit<D> for NeoTrellis<D> {
     fn init(mut self) -> Result<Self, Self::Error> {

--- a/src/devices/neotrellis.rs
+++ b/src/devices/neotrellis.rs
@@ -38,10 +38,11 @@ impl<D: Driver> NeoTrellis<D> {
         &mut self,
         x: u8,
         y: u8,
-        r: u8,
-        g: u8,
-        b: u8,
-    ) -> Result<(), SeesawError<D::Error>> {
-        self.set_nth_neopixel_color((y * Self::NUM_COLS + x).into(), r, g, b)
+        color: NeoTrellisColor,
+    ) -> Result<(), SeesawError<D::Error>>
+    where
+        [(); 2 + Self::C_SIZE]: Sized,
+    {
+        self.set_nth_neopixel_color((y * Self::NUM_COLS + x).into(), color)
     }
 }

--- a/src/devices/rotary_encoder.rs
+++ b/src/devices/rotary_encoder.rs
@@ -12,7 +12,7 @@ seesaw_device! {
   modules:  [
       EncoderModule { num_encoders: 1, encoder_btn_pins: [24] },
       GpioModule,
-      NeopixelModule { num_leds: 1, pin: 6 },
+      NeopixelModule<color_type = rgb::Rgb<u8>> { num_leds: 1, pin: 6 },
   ]
 }
 

--- a/src/devices/rotary_encoder.rs
+++ b/src/devices/rotary_encoder.rs
@@ -12,9 +12,11 @@ seesaw_device! {
   modules:  [
       EncoderModule { num_encoders: 1, encoder_btn_pins: [24] },
       GpioModule,
-      NeopixelModule<color_type = rgb::Rgb<u8>> { num_leds: 1, pin: 6 },
+      NeopixelModule<color_type = RotaryEncoderColor> { num_leds: 1, pin: 6 },
   ]
 }
+
+pub type RotaryEncoderColor = rgb::Grb<u8>;
 
 impl<D: Driver> SeesawDeviceInit<D> for RotaryEncoder<D> {
     fn init(mut self) -> Result<Self, Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 #![allow(const_evaluatable_unchecked, incomplete_features, rustdoc::bare_urls)]
 #![feature(array_try_map, generic_const_exprs)]
 // TODO improve the organization of the exports/visibility
+// Re-export rgb
+pub use rgb;
+
 pub mod bus;
 pub mod devices;
 pub mod modules;

--- a/src/modules/neopixel.rs
+++ b/src/modules/neopixel.rs
@@ -1,3 +1,5 @@
+use rgb::ComponentSlice;
+
 use super::{Modules, Reg};
 use crate::{devices::SeesawDevice, driver::Driver, DriverExt, SeesawError};
 
@@ -27,6 +29,8 @@ pub trait NeopixelModule<D: Driver>: SeesawDevice<Driver = D> {
 
     /// The number of neopixels on the device
     const N_LEDS: u16 = 1;
+
+    type C: ComponentSlice<u8>;
 
     fn enable_neopixel(&mut self) -> Result<(), SeesawError<D::Error>> {
         let addr = self.addr();


### PR DESCRIPTION
### Added

- [#14](https://github.com/alexeden/adafruit-seesaw/pull/14) Add and re-export the [`rgb`](https://docs.rs/rgb/0.8.50/rgb/index.html) crate for all things related to color

### Modified

- **BREAKING** [#14](https://github.com/alexeden/adafruit-seesaw/pull/14) The `NeopixelModule` now has a `Color` associated type that must implement the `ComponentSlice<u8>` trait from the `rgb` crate
  - For convenience, any device that implements the `NeopixelModule` trait exports a type alias for its `Color` type, e.g. `NeoKey1x4Color`
  - The `impl_device_module!` macro has been updated accordingly when implementing the `NeopixelModule` for a device:
    - Before: `NeopixelModule { num_leds: 4, pin: 3 }`
    - After: `NeopixelModule<color_type = NeoKey1x4Color> { num_leds: 4, pin: 3 }`
- **BREAKING** [#14](https://github.com/alexeden/adafruit-seesaw/pull/14) Functions that set handle colors in the `NeopixelModule` now take their `Color` associated type as parameters
  - Before: `fn set_neopixel_color(&mut self, r: u8, g: u8, b: u8)`
  - After: `fn set_neopixel_color(&mut self, color: Self::Color)`
  - Before: `fn set_nth_neopixel_color(&mut self, n: usize, r: u8, g: u8, b: u8)`
  - After: `fn set_nth_neopixel_color(&mut self, n: usize, color: Self::Color)`
  - Before: `fn set_neopixel_colors(&mut self, colors: &[(u8, u8, u8); Self::N_LEDS as usize])`
  - After: `fn set_neopixel_colors(&mut self, colors: &[Self::Color; Self::N_LEDS])`
- [#14](https://github.com/alexeden/adafruit-seesaw/pull/14) All device examples have been updated to use the new `NeopixelModule` API
- [#12](https://github.com/alexeden/adafruit-seesaw/pull/12) The `register_write` function on the `Driver` trait has been modified such that it no longer uses/needs const generics for buffer sizing (thanks @dsheets)