### PR TITLE
add possibility to use `embedded-hal-bus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project (hopefully) adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
--
+### Added
+
+- [#18](https://github.com/alexeden/adafruit-seesaw/pull/18) Add `DirectI2cSeesaw` which avoids using a custom bus implementation. Use this together with [embedded-hal-bus](https://crates.io/crates/embedded-hal-bus).
 
 ## [0.11.0] - 2025-02-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ cortex-m-rt = "0.7"
 heapless = "0.8"
 rtt-target = { version = "0.6" }
 stm32f4xx-hal = { features = ["stm32f405", "sdio"], version = "0.20" }
+embedded-hal-bus = "0.3"
 
 [profile.release]
 codegen-units = 1

--- a/examples/embedded_hal_bus_test.rs
+++ b/examples/embedded_hal_bus_test.rs
@@ -1,0 +1,85 @@
+#![no_std]
+#![no_main]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use adafruit_seesaw::{
+    devices::{NeoSlider, RotaryEncoder},
+    prelude::*,
+    DirectI2cSeesaw,
+};
+use core::cell::RefCell;
+use cortex_m_rt::entry;
+use rtt_target::{rprintln, rtt_init_print};
+use stm32f4xx_hal::{gpio::GpioExt, i2c::I2c, pac, prelude::*, rcc::RccExt};
+
+#[entry]
+fn main() -> ! {
+    rtt_init_print!();
+    rprintln!("Begin");
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+    let gpiob = dp.GPIOB.split();
+    let clocks = dp.RCC.constrain().cfgr.freeze();
+    let scl = gpiob.pb6.into_alternate_open_drain::<4>();
+    let sda = gpiob.pb7.into_alternate_open_drain::<4>();
+    let i2c = I2c::new(dp.I2C1, (scl, sda), 400.kHz(), &clocks);
+    let i2c_ref_cell = RefCell::new(i2c);
+
+    let encoder_delay = cp.SYST.delay(&clocks);
+    let seesaw_encoder = DirectI2cSeesaw::new(
+        encoder_delay,
+        embedded_hal_bus::i2c::RefCellDevice::new(&i2c_ref_cell),
+    );
+    let mut encoder = RotaryEncoder::new_with_default_addr(seesaw_encoder)
+        .init()
+        .expect("Failed to start RotaryEncoder");
+    rprintln!(
+        "Encoder Capabilities {:#?}",
+        encoder.capabilities().expect("Failed to get options")
+    );
+
+    let neoslider_delay = dp.TIM2.delay_us(&clocks);
+    let seesaw_neoslider = DirectI2cSeesaw::new(
+        neoslider_delay,
+        embedded_hal_bus::i2c::RefCellDevice::new(&i2c_ref_cell),
+    );
+    let mut neoslider = NeoSlider::new_with_default_addr(seesaw_neoslider)
+        .init()
+        .expect("Failed to start RotaryEncoder");
+    rprintln!(
+        "Neoslider Capabilities {:#?}",
+        neoslider.capabilities().expect("Failed to get options")
+    );
+
+    rprintln!("Looping...");
+    let mut prev_encoder_position = 0;
+    let mut prev_slider_value = 0;
+    loop {
+        let encoder_position = encoder.position(0).expect("Failed to get encoder position");
+        if encoder_position != prev_encoder_position {
+            prev_encoder_position = encoder_position;
+            rprintln!("Position changed to {}", encoder_position);
+        }
+        let slider_value = neoslider.slider_value().expect("Failed to read slider");
+        if slider_value != prev_slider_value {
+            prev_slider_value = slider_value;
+            rprintln!("Slider value changed to {}", slider_value);
+        }
+    }
+}
+
+#[panic_handler]
+fn handle_panic(info: &core::panic::PanicInfo) -> ! {
+    rprintln!("PANIC! {}", info.message());
+    if let Some(location) = info.location() {
+        rprintln!(
+            "Panic occurred in file '{}' at line {}",
+            location.file(),
+            location.line(),
+        );
+    } else {
+        rprintln!("Panic occurred but can't get location information...");
+    }
+    loop {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,11 @@ pub mod prelude {
 mod driver;
 use bus::{Bus, BusMutex, RefCellBus};
 pub use driver::*;
-use embedded_hal::{delay::DelayNs, i2c::I2c};
+use embedded_hal::{
+    delay::DelayNs,
+    i2c,
+    i2c::{ErrorType, I2c},
+};
 use modules::HardwareId;
 
 pub type SeesawRefCell<BUS> = Seesaw<RefCellBus<BUS>>;
@@ -29,7 +33,11 @@ pub type SeesawRefCell<BUS> = Seesaw<RefCellBus<BUS>>;
 #[cfg(feature = "std")]
 pub type SeesawStdMutex<BUS> = Seesaw<std::sync::Mutex<BUS>>;
 
-/// The owner of the driver from which new seesaw devices can be created
+/// The owner of the driver from which new seesaw devices can be created.
+/// Use this with a custom bus implementation from this crate.
+///
+/// If you instead wish to use [`embedded-hal-bus`](https://crates.io/crates/embedded-hal-bus),
+/// then you should use [`DirectI2cSeesaw`].
 pub struct Seesaw<M>(M);
 
 impl<DELAY, I2C, M> Seesaw<M>
@@ -44,6 +52,53 @@ where
 
     pub fn acquire_driver(&self) -> Bus<'_, M> {
         Bus(&self.0)
+    }
+}
+
+/// Unlike [`Seesaw`] this does *not* implement a custom bus.
+/// Instead, you either use a single device with it or you use
+/// [`embedded-hal-bus`](https://crates.io/crates/embedded-hal-bus).
+pub struct DirectI2cSeesaw<DELAY, I2C> {
+    delay: DELAY,
+    i2c: I2C,
+}
+
+impl<DELAY, I2C> DirectI2cSeesaw<DELAY, I2C> {
+    pub fn new(delay: DELAY, i2c: I2C) -> Self {
+        Self { delay, i2c }
+    }
+}
+
+// Delay implementation
+impl<DELAY, I2C> DelayNs for DirectI2cSeesaw<DELAY, I2C>
+where
+    DELAY: DelayNs,
+    I2C: I2c,
+{
+    fn delay_ns(&mut self, ns: u32) {
+        self.delay.delay_ns(ns)
+    }
+}
+
+impl<DELAY, I2C> ErrorType for DirectI2cSeesaw<DELAY, I2C>
+where
+    DELAY: DelayNs,
+    I2C: I2c,
+{
+    type Error = I2C::Error;
+}
+
+impl<DELAY, I2C> I2c for DirectI2cSeesaw<DELAY, I2C>
+where
+    DELAY: DelayNs,
+    I2C: I2c,
+{
+    fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        self.i2c.transaction(address, operations)
     }
 }
 


### PR DESCRIPTION
this isn't particularly nice, but it avoids re-writing the complete library to kick out `Driver: I2c + DelayNs` which permeates all of the code.

a better name might be required for this!

note that depending on the HAL you might have the possibility to clone the delay or instantiate a generic new one every time (e.g. using `embassy_time::Delay`).

resolves #16