### PR TITLE
add possibility to disable devices/modules & build on stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,42 @@ env:
 
 
 jobs:
-  lint:
-    name: Lint
+  build-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        features: [
+          '-F device_neokey_1x4',
+          '-F device_neorotary4',
+          '-F device_neoslider',
+          '-F device_rotary_encoder',
+        ]
+    name: Build & Lint (Default Features, Stable)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain install nightly --profile minimal --component clippy
+      - run: rustup toolchain install stable --component clippy
+      - run: cargo build --no-default-features ${features}
+      - run: cargo clippy --no-default-features ${features}
+
+  build-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        features: [
+          '-F device_arcade_button_1x4',
+          '-F device_neokey_1x4,module_neopixel',
+          '-F device_neorotary4,module_neopixel',
+          '-F device_neoslider,module_neopixel',
+          '-F device_neotrellis',
+          '-F device_neotrellis,module_neopixel',
+          '-F device_rotary_encoder,module_neopixel',
+        ]
+    name: Build & Lint With Features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install nightly --component clippy
       - run: rustup default nightly
-      - run: cargo clippy
+      - run: cargo build --no-default-features ${features}
+      - run: cargo clippy --no-default-features ${features}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project (hopefully) adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
--
+### Added
+
+- [#19](https://github.com/alexeden/adafruit-seesaw/pull/19) Add one feature per device and module, allowing disabling all and only enabling those needed. This allows building some of them on stable rust.
 
 ## [0.11.0] - 2025-02-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ device_neotrellis = ["module_keypad"]
 device_rotary_encoder = ["module_encoder", "module_gpio"]
 
 module_adc = []
-module_encoder = []
+module_encoder = ["module_gpio"]
 module_gpio = []
 module_keypad = []
 module_neopixel = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,34 @@ all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [features]
+default = [
+    "device_arcade_button_1x4",
+    "device_neokey_1x4",
+    "device_neorotary4",
+    "device_neoslider",
+    "device_neotrellis",
+    "device_rotary_encoder",
+
+    "module_keypad",
+    "module_neopixel",
+]
+
 std = []
+
+# devices only depend on the modules which they absolutely need for the basics to work
+device_arcade_button_1x4 = ["module_gpio", "module_timer"]
+device_neokey_1x4 = ["module_gpio"]
+device_neorotary4 = ["module_gpio", "module_encoder"]
+device_neoslider = ["module_adc", "module_gpio"]
+device_neotrellis = ["module_keypad"]
+device_rotary_encoder = ["module_encoder", "module_gpio"]
+
+module_adc = []
+module_encoder = []
+module_gpio = []
+module_keypad = []
+module_neopixel = []
+module_timer = []
 
 [lib]
 bench = false

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,21 +1,33 @@
+#[cfg(feature = "device_arcade_button_1x4")]
 mod arcade_button_1x4;
 mod generic_device;
 pub mod macros;
+#[cfg(feature = "device_neokey_1x4")]
 mod neokey_1x4;
+#[cfg(feature = "device_neorotary4")]
 mod neorotary4;
+#[cfg(feature = "device_neoslider")]
 mod neoslider;
+#[cfg(feature = "device_neotrellis")]
 mod neotrellis;
+#[cfg(feature = "device_rotary_encoder")]
 mod rotary_encoder;
 use crate::{
     modules::{status::StatusModule, HardwareId},
     Driver, SeesawError,
 };
+#[cfg(feature = "device_arcade_button_1x4")]
 pub use arcade_button_1x4::*;
 pub use generic_device::*;
+#[cfg(feature = "device_neokey_1x4")]
 pub use neokey_1x4::*;
+#[cfg(feature = "device_neorotary4")]
 pub use neorotary4::*;
+#[cfg(feature = "device_neoslider")]
 pub use neoslider::*;
+#[cfg(feature = "device_neotrellis")]
 pub use neotrellis::*;
+#[cfg(feature = "device_rotary_encoder")]
 pub use rotary_encoder::*;
 
 pub trait SeesawDevice {

--- a/src/devices/neokey_1x4.rs
+++ b/src/devices/neokey_1x4.rs
@@ -2,12 +2,13 @@ use super::SeesawDeviceInit;
 use crate::{
     modules::{
         gpio::{GpioModule, PinMode},
-        neopixel::NeopixelModule,
         status::StatusModule,
         HardwareId,
     },
     seesaw_device, Driver, SeesawError,
 };
+#[cfg(feature = "module_neopixel")]
+use crate::modules::neopixel::NeopixelModule;
 
 seesaw_device! {
   /// NeoKey1x4
@@ -20,6 +21,7 @@ seesaw_device! {
 pub type NeoKey1x4Color = rgb::Grb<u8>;
 
 impl<D: Driver> GpioModule<D> for NeoKey1x4<D> {}
+#[cfg(feature = "module_neopixel")]
 impl<D: Driver> NeopixelModule<D> for NeoKey1x4<D> {
     type Color = NeoKey1x4Color;
 
@@ -29,10 +31,11 @@ impl<D: Driver> NeopixelModule<D> for NeoKey1x4<D> {
 
 impl<D: Driver> SeesawDeviceInit<D> for NeoKey1x4<D> {
     fn init(mut self) -> Result<Self, SeesawError<D::Error>> {
-        self.reset_and_verify_seesaw()
-            .and_then(|_| self.enable_neopixel())
-            .and_then(|_| self.enable_button_pins())
-            .map(|_| self)
+        self.reset_and_verify_seesaw()?;
+        self.enable_button_pins()?;
+        #[cfg(feature = "module_neopixel")]
+        self.enable_neopixel()?;
+        Ok(self)
     }
 }
 

--- a/src/devices/neorotary4.rs
+++ b/src/devices/neorotary4.rs
@@ -1,9 +1,11 @@
 use super::SeesawDeviceInit;
 use crate::{
-    modules::{encoder::EncoderModule, neopixel::NeopixelModule, status::StatusModule, HardwareId},
+    modules::{encoder::EncoderModule, status::StatusModule, HardwareId},
     prelude::GpioModule,
     seesaw_device, Driver, SeesawError,
 };
+#[cfg(feature = "module_neopixel")]
+use crate::modules::neopixel::NeopixelModule;
 
 seesaw_device! {
     /// Anecdotally, I've had a lot of issues with the quad rotary encoder.
@@ -22,6 +24,7 @@ impl<D: Driver> GpioModule<D> for NeoRotary4<D> {}
 impl<D: Driver> EncoderModule<D, 4> for NeoRotary4<D> {
     const ENCODER_BTN_PINS: [u8; 4] = [12, 14, 17, 9];
 }
+#[cfg(feature = "module_neopixel")]
 impl<D: Driver> NeopixelModule<D> for NeoRotary4<D> {
     type Color = NeoRotary4Color;
 
@@ -31,12 +34,13 @@ impl<D: Driver> NeopixelModule<D> for NeoRotary4<D> {
 
 impl<D: Driver> SeesawDeviceInit<D> for NeoRotary4<D> {
     fn init(mut self) -> Result<Self, SeesawError<D::Error>> {
-        self.reset_and_verify_seesaw()
-            .and_then(|_| self.enable_neopixel())
-            .and_then(|_| self.enable_button(0))
-            .and_then(|_| self.enable_button(1))
-            .and_then(|_| self.enable_button(2))
-            .and_then(|_| self.enable_button(3))
-            .map(|_| self)
+        self.reset_and_verify_seesaw()?;
+        self.enable_button(0)?;
+        self.enable_button(1)?;
+        self.enable_button(2)?;
+        self.enable_button(3)?;
+        #[cfg(feature = "module_neopixel")]
+        self.enable_neopixel()?;
+        Ok(self)
     }
 }

--- a/src/devices/neoslider.rs
+++ b/src/devices/neoslider.rs
@@ -1,11 +1,13 @@
 use super::SeesawDeviceInit;
 use crate::{
     modules::{
-        adc::AdcModule, gpio::GpioModule, neopixel::NeopixelModule, status::StatusModule,
+        adc::AdcModule, gpio::GpioModule, status::StatusModule,
         HardwareId,
     },
     seesaw_device, Driver, SeesawError,
 };
+#[cfg(feature = "module_neopixel")]
+use crate::modules::neopixel::NeopixelModule;
 
 seesaw_device!(
   /// NeoSlider
@@ -19,6 +21,7 @@ pub type NeoSliderColor = rgb::Grb<u8>;
 
 impl<D: Driver> AdcModule<D> for NeoSlider<D> {}
 impl<D: Driver> GpioModule<D> for NeoSlider<D> {}
+#[cfg(feature = "module_neopixel")]
 impl<D: Driver> NeopixelModule<D> for NeoSlider<D> {
     type Color = NeoSliderColor;
 
@@ -28,9 +31,10 @@ impl<D: Driver> NeopixelModule<D> for NeoSlider<D> {
 
 impl<D: Driver> SeesawDeviceInit<D> for NeoSlider<D> {
     fn init(mut self) -> Result<Self, SeesawError<D::Error>> {
-        self.reset_and_verify_seesaw()
-            .and_then(|_| self.enable_neopixel())
-            .map(|_| self)
+        self.reset_and_verify_seesaw()?;
+        #[cfg(feature = "module_neopixel")]
+        self.enable_neopixel()?;
+        Ok(self)
     }
 }
 

--- a/src/devices/neotrellis.rs
+++ b/src/devices/neotrellis.rs
@@ -1,8 +1,10 @@
 use super::SeesawDeviceInit;
 use crate::{
-    modules::{keypad::KeypadModule, neopixel::NeopixelModule, status::StatusModule, HardwareId},
+    modules::{keypad::KeypadModule, status::StatusModule, HardwareId},
     seesaw_device, Driver, SeesawError,
 };
+#[cfg(feature = "module_neopixel")]
+use crate::modules::neopixel::NeopixelModule;
 
 seesaw_device! {
     name: NeoTrellis,
@@ -18,6 +20,7 @@ impl<D: Driver> KeypadModule<D> for NeoTrellis<D> {
     const NUM_ROWS: u8 = 4;
 }
 
+#[cfg(feature = "module_neopixel")]
 impl<D: Driver> NeopixelModule<D> for NeoTrellis<D> {
     type Color = NeoTrellisColor;
 
@@ -27,9 +30,10 @@ impl<D: Driver> NeopixelModule<D> for NeoTrellis<D> {
 
 impl<D: Driver> SeesawDeviceInit<D> for NeoTrellis<D> {
     fn init(mut self) -> Result<Self, SeesawError<D::Error>> {
-        self.reset_and_verify_seesaw()
-            .and_then(|_| self.enable_neopixel())
-            .map(|_| self)
+        self.reset_and_verify_seesaw()?;
+        #[cfg(feature = "module_neopixel")]
+        self.enable_neopixel()?;
+        Ok(self)
     }
 }
 

--- a/src/devices/rotary_encoder.rs
+++ b/src/devices/rotary_encoder.rs
@@ -1,11 +1,13 @@
 use super::SeesawDeviceInit;
 use crate::{
     modules::{
-        encoder::EncoderModule, gpio::GpioModule, neopixel::NeopixelModule, status::StatusModule,
+        encoder::EncoderModule, gpio::GpioModule, status::StatusModule,
         HardwareId,
     },
     seesaw_device, Driver, SeesawError,
 };
+#[cfg(feature = "module_neopixel")]
+use crate::modules::neopixel::NeopixelModule;
 
 seesaw_device! {
   name: RotaryEncoder,
@@ -20,6 +22,8 @@ impl<D: Driver> GpioModule<D> for RotaryEncoder<D> {}
 impl<D: Driver> EncoderModule<D, 1> for RotaryEncoder<D> {
     const ENCODER_BTN_PINS: [u8; 1] = [24];
 }
+
+#[cfg(feature = "module_neopixel")]
 impl<D: Driver> NeopixelModule<D> for RotaryEncoder<D> {
     type Color = RotaryEncoderColor;
 
@@ -29,9 +33,10 @@ impl<D: Driver> NeopixelModule<D> for RotaryEncoder<D> {
 
 impl<D: Driver> SeesawDeviceInit<D> for RotaryEncoder<D> {
     fn init(mut self) -> Result<Self, SeesawError<D::Error>> {
-        self.reset_and_verify_seesaw()
-            .and_then(|_| self.enable_button(0))
-            .and_then(|_| self.enable_neopixel())
-            .map(|_| self)
+        self.reset_and_verify_seesaw()?;
+        self.enable_button(0)?;
+        #[cfg(feature = "module_neopixel")]
+        self.enable_neopixel()?;
+        Ok(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(const_evaluatable_unchecked, incomplete_features, rustdoc::bare_urls)]
-#![feature(array_try_map, generic_const_exprs)]
+#![cfg_attr(feature = "module_neopixel", feature(array_try_map, generic_const_exprs))]
 // TODO improve the organization of the exports/visibility
 // Re-export rgb
 pub use rgb;
@@ -14,15 +14,29 @@ pub mod prelude {
         devices::{SeesawDevice, SeesawDeviceInit},
         driver::DriverExt,
         modules::{
-            adc::*, encoder::*, gpio::*, keypad::*, neopixel::*, status::*, timer::*, HardwareId,
+            status::*, HardwareId,
         },
     };
+    #[cfg(feature = "module_adc")]
+    pub use super::modules::adc::*;
+    #[cfg(feature = "module_encoder")]
+    pub use super::modules::encoder::*;
+    #[cfg(feature = "module_gpio")]
+    pub use super::modules::gpio::*;
+    #[cfg(feature = "module_keypad")]
+    pub use super::modules::keypad::*;
+    #[cfg(feature = "module_neopixel")]
+    pub use super::modules::neopixel::*;
+    #[cfg(feature = "module_timer")]
+    pub use super::modules::timer::*;
 }
 mod driver;
 use bus::{Bus, BusMutex, RefCellBus};
 pub use driver::*;
-use embedded_hal::{delay::DelayNs, i2c::I2c};
-use modules::HardwareId;
+use embedded_hal::{
+    delay::DelayNs,
+    i2c::I2c,
+};
 
 pub type SeesawRefCell<BUS> = Seesaw<RefCellBus<BUS>>;
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,9 +1,15 @@
+#[cfg(feature = "module_adc")]
 pub mod adc;
+#[cfg(feature = "module_encoder")]
 pub mod encoder;
+#[cfg(feature = "module_gpio")]
 pub mod gpio;
+#[cfg(feature = "module_keypad")]
 pub mod keypad;
+#[cfg(feature = "module_neopixel")]
 pub mod neopixel;
 pub mod status;
+#[cfg(feature = "module_timer")]
 pub mod timer;
 
 pub type Reg = [u8; 2];

--- a/src/modules/timer.rs
+++ b/src/modules/timer.rs
@@ -1,5 +1,5 @@
 use super::{Modules, Reg};
-use crate::{devices::SeesawDevice, Driver, DriverExt, HardwareId, SeesawError};
+use crate::{devices::SeesawDevice, Driver, DriverExt, modules::HardwareId, SeesawError};
 
 /// WO - 16 bits
 /// The first byte of the register indicates which PWM pin will have its value


### PR DESCRIPTION
some devices (and modules) use nightly-only features. making it possible to disable default features and only selectively enabling the devices & modules which one needs allows using some of them with stable rust, making it much more convenient to use this library without requiring re-writing the library to avoid the usage of the nightly features.

the default features are set up to enable everything, thus there is no functional impact on existing consumers.