### PR TITLE
Add SoilSensor Device Support

### DIFF
--- a/examples/soilsensor_test.rs
+++ b/examples/soilsensor_test.rs
@@ -3,14 +3,11 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 use adafruit_seesaw::{
-    devices::{NeoKey1x4, NeoKey1x4Color, SoilSensor}, modules::touch::{self, TouchModule}, prelude::*, SeesawRefCell
+    devices::SoilSensor, modules::touch::TouchModule, prelude::*, SeesawRefCell
 };
 use cortex_m_rt::entry;
 use rtt_target::{rprintln, rtt_init_print};
 use stm32f4xx_hal::{gpio::GpioExt, i2c::I2c, pac, prelude::*, rcc::RccExt};
-
-const RED: NeoKey1x4Color = NeoKey1x4Color { r: 255, g: 0, b: 0 };
-const GREEN: NeoKey1x4Color = NeoKey1x4Color { r: 0, g: 255, b: 0 };
 
 #[entry]
 fn main() -> ! {

--- a/examples/soilsensor_test.rs
+++ b/examples/soilsensor_test.rs
@@ -1,0 +1,53 @@
+#![no_std]
+#![no_main]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+use adafruit_seesaw::{
+    devices::{NeoKey1x4, NeoKey1x4Color, SoilSensor}, modules::touch::{self, TouchModule}, prelude::*, SeesawRefCell
+};
+use cortex_m_rt::entry;
+use rtt_target::{rprintln, rtt_init_print};
+use stm32f4xx_hal::{gpio::GpioExt, i2c::I2c, pac, prelude::*, rcc::RccExt};
+
+const RED: NeoKey1x4Color = NeoKey1x4Color { r: 255, g: 0, b: 0 };
+const GREEN: NeoKey1x4Color = NeoKey1x4Color { r: 0, g: 255, b: 0 };
+
+#[entry]
+fn main() -> ! {
+    rtt_init_print!();
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+    let gpiob = dp.GPIOB.split();
+    let clocks = dp.RCC.constrain().cfgr.freeze();
+    let mut delay = cp.SYST.delay(&clocks);
+    let scl = gpiob.pb6.into_alternate_open_drain::<4>();
+    let sda = gpiob.pb7.into_alternate_open_drain::<4>();
+    let i2c = I2c::new(dp.I2C1, (scl, sda), 100.kHz(), &clocks);
+    let seesaw = SeesawRefCell::new(delay, i2c);
+    let mut soil_sensor = SoilSensor::new_with_default_addr(seesaw.acquire_driver())
+        .init()
+        .expect("Failed to start SoilSensor");
+
+    loop {
+        let touch_capacitance = soil_sensor.read_touch_capacitance();
+
+        rprintln!("Current touch capacitance: {}", touch_capacitance);
+
+        delay.delay_ms(1_000);
+    }
+}
+
+#[panic_handler]
+fn handle_panic(info: &core::panic::PanicInfo) -> ! {
+    rprintln!("PANIC! {}", info.message());
+    if let Some(location) = info.location() {
+        rprintln!(
+            "Panic occurred in file '{}' at line {}",
+            location.file(),
+            location.line(),
+        );
+    } else {
+        rprintln!("Panic occurred but can't get location information...");
+    }
+    loop {}
+}

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -6,6 +6,7 @@ mod neorotary4;
 mod neoslider;
 mod neotrellis;
 mod rotary_encoder;
+mod soil_sensor;
 use crate::{
     modules::{status::StatusModule, HardwareId},
     Driver, SeesawError,

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -17,6 +17,7 @@ pub use neorotary4::*;
 pub use neoslider::*;
 pub use neotrellis::*;
 pub use rotary_encoder::*;
+pub use soil_sensor::*;
 
 pub trait SeesawDevice {
     type Driver: crate::Driver;

--- a/src/devices/soil_sensor.rs
+++ b/src/devices/soil_sensor.rs
@@ -1,0 +1,17 @@
+use super::SeesawDeviceInit;
+use crate::{
+    modules::{
+        gpio::{GpioModule, PinMode},
+        neopixel::NeopixelModule,
+        status::StatusModule,
+        HardwareId,
+    },
+    seesaw_device, Driver, SeesawError,
+};
+
+seesaw_device!(
+    name: SoilSensor,
+    hardware_id: HardwareId::SAMD09,
+    product_id: 4026,
+    default_addr: 0x36
+);

--- a/src/devices/soil_sensor.rs
+++ b/src/devices/soil_sensor.rs
@@ -1,10 +1,7 @@
 use super::SeesawDeviceInit;
 use crate::{
     modules::{
-        gpio::{GpioModule, PinMode},
-        neopixel::NeopixelModule,
-        status::StatusModule,
-        HardwareId,
+        gpio::{GpioModule, PinMode}, neopixel::NeopixelModule, status::StatusModule, touch::TouchModule, HardwareId
     },
     seesaw_device, Driver, SeesawError,
 };
@@ -15,3 +12,12 @@ seesaw_device!(
     product_id: 4026,
     default_addr: 0x36
 );
+
+impl<D: Driver> TouchModule<D> for SoilSensor<D> {}
+
+impl<D: Driver> SeesawDeviceInit<D> for SoilSensor<D> {
+    fn init(mut self) -> Result<Self, SeesawError<D::Error>> {
+        self.reset_and_verify_seesaw()
+            .map(|_| self)
+    }
+}

--- a/src/devices/soil_sensor.rs
+++ b/src/devices/soil_sensor.rs
@@ -1,9 +1,13 @@
 use super::SeesawDeviceInit;
 use crate::{
     modules::{
-        gpio::{GpioModule, PinMode}, neopixel::NeopixelModule, status::StatusModule, touch::TouchModule, HardwareId
+        status::StatusModule, 
+        touch::TouchModule, 
+        HardwareId,
     },
-    seesaw_device, Driver, SeesawError,
+    seesaw_device, 
+    Driver, 
+    SeesawError,
 };
 
 seesaw_device!(

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -11,7 +11,7 @@ pub trait Driver: I2c + DelayNs {}
 impl<T> Driver for T where T: I2c + DelayNs {}
 
 macro_rules! impl_integer_write {
-    ($fn:ident $nty:tt) => {
+    ($fn:ident $fn_with_delay:ident $nty:tt) => {
         fn $fn(
             &mut self,
             addr: SevenBitAddress,
@@ -20,13 +20,28 @@ macro_rules! impl_integer_write {
         ) -> Result<(), Self::Error> {
             self.register_write(addr, reg, &<$nty>::to_be_bytes(value))
         }
+
+        fn $fn_with_delay(
+            &mut self,
+            addr: SevenBitAddress,
+            reg: &Reg,
+            value: $nty,
+            delay: u32,
+        ) -> Result<(), Self::Error> {
+            self.register_write_with_delay(addr, reg, &<$nty>::to_be_bytes(value), delay)
+        }
     };
 }
 
 macro_rules! impl_integer_read {
-    ($fn:ident $nty:tt) => {
+    ($fn:ident $fn_with_delay:ident $nty:tt) => {
         fn $fn(&mut self, addr: SevenBitAddress, reg: &Reg) -> Result<$nty, Self::Error> {
             self.register_read::<{ ($nty::BITS / 8) as usize }>(addr, reg)
+                .map($nty::from_be_bytes)
+        }
+
+        fn $fn_with_delay(&mut self, addr: SevenBitAddress, reg: &Reg, delay: u32) -> Result<$nty, Self::Error> {
+            self.register_read_with_delay::<{ ($nty::BITS / 8) as usize }>(addr, reg, delay)
                 .map($nty::from_be_bytes)
         }
     };
@@ -35,50 +50,44 @@ macro_rules! impl_integer_read {
 pub trait DriverExt {
     type Error;
 
-    fn register_read<const N: usize>(
+    fn register_read_with_delay<const N: usize>(
         &mut self,
         addr: SevenBitAddress,
         reg: &Reg,
+        delay: u32,
     ) -> Result<[u8; N], Self::Error>;
 
-    fn register_write(
+    fn register_write_with_delay(
         &mut self,
         addr: SevenBitAddress,
         reg: &Reg,
         bytes: &[u8],
+        delay: u32,
     ) -> Result<(), Self::Error>;
 
-    impl_integer_read! { read_u8 u8 }
-    impl_integer_read! { read_u16 u16 }
-    impl_integer_read! { read_u32 u32 }
-    impl_integer_read! { read_u64 u64 }
-    impl_integer_read! { read_i8 i8 }
-    impl_integer_read! { read_i16 i16 }
-    impl_integer_read! { read_i32 i32 }
-    impl_integer_read! { read_i64 i64 }
-    impl_integer_write! { write_u8 u8 }
-    impl_integer_write! { write_u16 u16 }
-    impl_integer_write! { write_u32 u32 }
-    impl_integer_write! { write_u64 u64 }
-    impl_integer_write! { write_i8 i8 }
-    impl_integer_write! { write_i16 i16 }
-    impl_integer_write! { write_i32 i32 }
-    impl_integer_write! { write_i64 i64 }
-}
-
-impl<T: Driver> DriverExt for T {
-    type Error = T::Error;
+    impl_integer_read! { read_u8 read_u8_with_delay u8 }
+    impl_integer_read! { read_u16 read_u16_with_delay u16 }
+    impl_integer_read! { read_u32 read_u32_with_delay u32 }
+    impl_integer_read! { read_u64 read_u64_with_delay u64 }
+    impl_integer_read! { read_i8 read_i8_with_delay i8 }
+    impl_integer_read! { read_i16 read_i16_with_delay i16 }
+    impl_integer_read! { read_i32 read_i32_with_delay i32 }
+    impl_integer_read! { read_i64 read_i64_with_delay i64 }
+    impl_integer_write! { write_u8 write_u8_with_delay u8 }
+    impl_integer_write! { write_u16 write_u16_with_delay u16 }
+    impl_integer_write! { write_u32 write_u32_with_delay u32 }
+    impl_integer_write! { write_u64 write_u64_with_delay u64 }
+    impl_integer_write! { write_i8 write_i8_with_delay i8 }
+    impl_integer_write! { write_i16 write_i16_with_delay i16 }
+    impl_integer_write! { write_i32 write_i32_with_delay i32 }
+    impl_integer_write! { write_i64 write_i64_with_delay i64 }
 
     fn register_read<const N: usize>(
         &mut self,
         addr: SevenBitAddress,
         reg: &Reg,
     ) -> Result<[u8; N], Self::Error> {
-        let mut buffer = [0u8; N];
-        self.write(addr, reg)?;
-        self.delay_us(DELAY_TIME);
-        self.read(addr, &mut buffer)?;
-        Ok(buffer)
+        self.register_read_with_delay(addr, reg, DELAY_TIME)
     }
 
     fn register_write(
@@ -87,8 +96,35 @@ impl<T: Driver> DriverExt for T {
         reg: &Reg,
         bytes: &[u8],
     ) -> Result<(), Self::Error> {
+        self.register_write_with_delay(addr, reg, bytes, DELAY_TIME)
+    }
+}
+
+impl<T: Driver> DriverExt for T {
+    type Error = T::Error;
+
+    fn register_read_with_delay<const N: usize>(
+        &mut self,
+        addr: SevenBitAddress,
+        reg: &Reg,
+        delay: u32
+    ) -> Result<[u8; N], Self::Error> {
+        let mut buffer = [0u8; N];
+        self.write(addr, reg)?;
+        self.delay_us(delay);
+        self.read(addr, &mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn register_write_with_delay(
+        &mut self,
+        addr: SevenBitAddress,
+        reg: &Reg,
+        bytes: &[u8],
+        delay: u32
+    ) -> Result<(), Self::Error> {
         self.transaction(addr, &mut [Operation::Write(reg), Operation::Write(bytes)])?;
-        self.delay_us(DELAY_TIME);
+        self.delay_us(delay);
         Ok(())
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -5,6 +5,7 @@ pub mod keypad;
 pub mod neopixel;
 pub mod status;
 pub mod timer;
+pub mod touch;
 
 pub type Reg = [u8; 2];
 

--- a/src/modules/touch.rs
+++ b/src/modules/touch.rs
@@ -1,0 +1,18 @@
+use crate::{devices::SeesawDevice, Driver, DriverExt, SeesawError};
+
+use super::{Modules, Reg};
+
+// https://github.com/adafruit/Adafruit_Seesaw/blob/master/Adafruit_seesaw.cpp#L363
+// Delay of 3,000 us is used to read from the touch sensor. They also read the 
+// value in a retry loop but I haven't seen that be necessary to get data.
+const TOUCH_READ_DELAY: u32 = 3_000;
+
+const TOUCH: &Reg = &[Modules::Touch.into_u8(), 0x10];
+
+pub trait TouchModule<D: Driver>: SeesawDevice<Driver = D> {
+    fn read_touch_capacitance(&mut self) -> Result<u16, SeesawError<D::Error>> {
+        let addr = self.addr();
+        self.driver().read_u16_with_delay(addr, TOUCH, TOUCH_READ_DELAY)
+            .map_err(SeesawError::I2c)
+    }
+}


### PR DESCRIPTION
First of all, thanks for making this library, It was a breeze to integrate with!

This PR adds a new `SoilSensor` device based on the [Adafruit STEMMA Soil Sensor](https://www.adafruit.com/product/4026). Normally this would be pretty straightforward, but this sensor actually needs a longer delay after the register select write before it can read out the data. Adafruit's library uses a delay of 3,000 microseconds instead of the standard 125 microseconds used in the rest of this library.

That meant I needed to expose some extra functionality to be able to specify the delay between the write and the read for this device.

For the example, I don't actually have an STM board so I wasn't able to run it to test, but on my ESP32 board everything is working perfectly, so I just copied one of the other examples and used the `SoilSensor` device in place.