### PR TITLE
Add GPIO interrupt and pull resistor functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project (hopefully) adheres to [Semantic Versioning](https://semver.org
 
 ## [Unreleased]
 
--
+### Added
+
+- `GpioModule` interrupt functions: `interrupt_enable`, `interrupt_enable_bulk`, `interrupt_disable`, `interrupt_disable_bulk`, `clear_interrupts`
+- `GpioModule` pull resistor functions: `pull_enable`, `pull_enable_bulk`, `pull_disable`, `pull_disable_bulk`
+- `NeoKey1x4`: `enable_interrupts` and `disable_interrupts` convenience methods
+
+### Changed
+
+- `rgb` dependency bumped to `0.8.53`
+
+### Removed
+
+- `InterruptMode` enum (wasn't being used anywhere)
 
 ## [0.13.0] - 2026-01-24
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ test = false
 
 [dependencies]
 embedded-hal = "1.0.0"
-rgb = "0.8.50"
+rgb = "0.8.53"
 defmt = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/src/devices/neokey_1x4.rs
+++ b/src/devices/neokey_1x4.rs
@@ -47,6 +47,14 @@ impl<D: Driver> NeoKey1x4<D> {
         )
     }
 
+    pub fn enable_interrupt(&mut self) -> Result<(), SeesawError<D::Error>> {
+        self.interrupt_enable_bulk((1 << 4) | (1 << 5) | (1 << 6) | (1 << 7))
+    }
+
+    pub fn disable_interrupt(&mut self) -> Result<(), SeesawError<D::Error>> {
+        self.interrupt_disable_bulk((1 << 4) | (1 << 5) | (1 << 6) | (1 << 7))
+    }
+
     pub fn keys(&mut self) -> Result<u8, SeesawError<D::Error>> {
         self.digital_read_bulk().map(|r| ((r >> 4) & 0xF) as u8)
     }

--- a/src/modules/gpio.rs
+++ b/src/modules/gpio.rs
@@ -4,7 +4,6 @@ use crate::{devices::SeesawDevice, Driver, DriverExt, SeesawError};
 /// WO - 32 bits
 /// Writing a 1 to any bit in this register sets the direction of the
 /// corresponding pin to OUTPUT. Writing 0 has no effect.
-#[allow(dead_code)]
 const SET_OUTPUT: &Reg = &[Modules::Gpio.into_u8(), 0x02];
 
 /// WO - 32 bits
@@ -32,27 +31,23 @@ const SET_LOW: &Reg = &[Modules::Gpio.into_u8(), 0x06];
 /// W0 - 32 bits
 /// Writing a 1 to any bit in this register toggles the corresponding pin.
 /// Writing 0 has no effect.
-#[allow(dead_code)]
 const TOGGLE: &Reg = &[Modules::Gpio.into_u8(), 0x07];
 
 /// WO - 32 bits
 /// Writing a 1 to any bit in this register enables the interrupt on the
 /// corresponding pin. When the value on this pin changes, the corresponding
 /// bit will be set in the INTFLAG register. Writing 0 has no effect.
-#[allow(dead_code)]
 const INT_ENABLE: &Reg = &[Modules::Gpio.into_u8(), 0x08];
 
 /// WO - 32 bits
 /// Writing a 1 to any bit in this register disables the interrupt on the
 /// corresponding pin. Writing 0 has no effect.
-#[allow(dead_code)]
 const INT_DISABLE: &Reg = &[Modules::Gpio.into_u8(), 0x09];
 
 /// RO - 32 bits
 /// This register hold the status of all GPIO interrupts.
 /// When an interrupt fires, the corresponding bit in this register gets
 /// set. Reading this register clears all interrupts.
-#[allow(dead_code)]
 const INT_FLAG: &Reg = &[Modules::Gpio.into_u8(), 0x0A];
 
 /// WO - 32 bits
@@ -66,7 +61,6 @@ const PULL_ENABLE: &Reg = &[Modules::Gpio.into_u8(), 0x0B];
 /// WO - 32 bits
 /// Writing a 1 to any bit in this register disables the pull up/down on the
 /// corresponding pin. Writing 0 has no effect.
-#[allow(dead_code)]
 const PULL_DISABLE: &Reg = &[Modules::Gpio.into_u8(), 0x0C];
 
 /// The GPIO module provides every day input and outputs. You'll get logic GPIO
@@ -110,6 +104,56 @@ pub trait GpioModule<D: Driver>: SeesawDevice<Driver = D> {
             PinOutput::Toggle => bus.write_u32(addr, TOGGLE, pins),
         }
         .map_err(SeesawError::I2c)
+    }
+
+    fn clear_interrupts(&mut self) -> Result<u32, SeesawError<D::Error>> {
+        let addr = self.addr();
+        let bus = self.driver();
+        bus.read_u32(addr, INT_FLAG).map_err(SeesawError::I2c)
+    }
+
+    fn interrupt_disable(&mut self, pin: u8) -> Result<(), SeesawError<D::Error>> {
+        self.interrupt_disable_bulk(1 << pin)
+    }
+
+    fn interrupt_disable_bulk(&mut self, pins: u32) -> Result<(), SeesawError<D::Error>> {
+        let addr = self.addr();
+        let bus = self.driver();
+        bus.write_u32(addr, INT_DISABLE, pins)
+            .map_err(SeesawError::I2c)
+    }
+
+    fn interrupt_enable(&mut self, pin: u8) -> Result<(), SeesawError<D::Error>> {
+        self.interrupt_enable_bulk(1 << pin)
+    }
+
+    fn interrupt_enable_bulk(&mut self, pins: u32) -> Result<(), SeesawError<D::Error>> {
+        let addr = self.addr();
+        let bus = self.driver();
+        bus.write_u32(addr, INT_ENABLE, pins)
+            .map_err(SeesawError::I2c)
+    }
+
+    fn pull_disable(&mut self, pin: u8) -> Result<(), SeesawError<D::Error>> {
+        self.pull_disable_bulk(1 << pin)
+    }
+
+    fn pull_disable_bulk(&mut self, pins: u32) -> Result<(), SeesawError<D::Error>> {
+        let addr = self.addr();
+        let bus = self.driver();
+        bus.write_u32(addr, PULL_DISABLE, pins)
+            .map_err(SeesawError::I2c)
+    }
+
+    fn pull_enable(&mut self, pin: u8) -> Result<(), SeesawError<D::Error>> {
+        self.pull_enable_bulk(1 << pin)
+    }
+
+    fn pull_enable_bulk(&mut self, pins: u32) -> Result<(), SeesawError<D::Error>> {
+        let addr = self.addr();
+        let bus = self.driver();
+        bus.write_u32(addr, PULL_ENABLE, pins)
+            .map_err(SeesawError::I2c)
     }
 
     fn set_pin_mode(&mut self, pin: u8, mode: PinMode) -> Result<(), SeesawError<D::Error>> {

--- a/src/modules/gpio.rs
+++ b/src/modules/gpio.rs
@@ -174,23 +174,3 @@ impl From<PinMode> for u8 {
         value as u8
     }
 }
-
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[repr(u8)]
-pub enum InterruptMode {
-    Disabled = 0x00,
-    Rising = 0x01,
-    Falling = 0x02,
-    Change = 0x03,
-    Onlow = 0x04,
-    Onhigh = 0x05,
-    OnlowWe = 0x0C,
-    OnhighWe = 0x0D,
-}
-
-impl From<InterruptMode> for u8 {
-    fn from(value: InterruptMode) -> Self {
-        value as u8
-    }
-}

--- a/src/modules/neopixel.rs
+++ b/src/modules/neopixel.rs
@@ -1,5 +1,6 @@
 use super::{Modules, Reg};
 use crate::{devices::SeesawDevice, driver::Driver, DriverExt, SeesawError};
+#[allow(deprecated)]
 use rgb::ComponentSlice;
 
 /// WO - 8 bits
@@ -37,6 +38,7 @@ pub trait NeopixelModule<D: Driver>: SeesawDevice<Driver = D> {
     /// The output pin of the neopixel signal
     const PIN: u8;
 
+    #[allow(deprecated)]
     type Color: ComponentSlice<u8>;
 
     /// Set which pin the device sends the neopixel signal through and
@@ -93,6 +95,7 @@ pub trait NeopixelModule<D: Driver>: SeesawDevice<Driver = D> {
         let addr = self.addr();
         let mut buf = [0; 2 + Self::C_SIZE];
         buf[..2].copy_from_slice(&u16::to_be_bytes((Self::C_SIZE * n) as u16));
+        #[allow(deprecated)]
         buf[2..].copy_from_slice(color.as_slice());
         self.driver()
             .register_write(addr, SET_BUF, &buf)
@@ -126,6 +129,7 @@ pub trait NeopixelModule<D: Driver>: SeesawDevice<Driver = D> {
                 buf[..2].copy_from_slice(&offset);
                 chunk.iter().enumerate().for_each(|(j, c)| {
                     let start = 2 + (j * Self::C_SIZE);
+                    #[allow(deprecated)]
                     buf[start..start + Self::C_SIZE].copy_from_slice(c.as_slice());
                 });
 


### PR DESCRIPTION
## Summary

- Adds `interrupt_enable`, `interrupt_enable_bulk`, `interrupt_disable`, `interrupt_disable_bulk`, and `clear_interrupts` to `GpioModule`
- Adds `pull_enable`, `pull_enable_bulk`, `pull_disable`, `pull_disable_bulk` to `GpioModule`
- Adds `enable_interrupts` / `disable_interrupts` convenience methods to `NeoKey1x4`
- Removes unused `InterruptMode` enum
- Bumps `rgb` to `0.8.53` and suppresses `ComponentSlice` deprecation warnings

## Test plan

- [ ] Build with `--features nightly` and verify no compiler errors
- [ ] Verify `NeoKey1x4::enable_interrupts` / `disable_interrupts` work on hardware